### PR TITLE
[readme] update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Ralexa
 
 Ruby client for Amazon Alexa APIs.
 
-These include [Alexa Top Sites][1] and [Alexa Web Information Service][2].
+These include [Alexa Top Sites][2] and [Alexa Web Information Service][1].
 
 HTTP transport thanks to `Net::HTTP`,
 with a little help from [addressable][3].


### PR DESCRIPTION
`Alexa Top Sites` and `Alexa Web Information Service` were switched :)

```
[1]: http://aws.amazon.com/awis/
[2]: http://aws.amazon.com/alexatopsites/
[3]: https://github.com/sporkmonger/addressable
[4]: http://nokogiri.org/
```