### PR TITLE
HTTP endpoint is deprecated in favour of HTTPS

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,3 +11,7 @@ Rake::TestTask.new do |t|
   # ENV["TESTOPTS"] = "-v"
   t.pattern = "spec/*_spec.rb"
 end
+
+task :console do
+  exec "irb -r ralexa -I ./lib"
+end

--- a/lib/ralexa/client.rb
+++ b/lib/ralexa/client.rb
@@ -24,7 +24,7 @@ module Ralexa
     def signed_uri(host, path, query_values)
       uri_signer.sign_uri(
         Addressable::URI.new(
-          scheme: "http",
+          scheme: "https",
           host: host,
           path: path,
           query_values: query_values

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -13,14 +13,14 @@ module Ralexa
     let(:response) { MiniTest::Mock.new }
 
     it "returns the response body of HTTP GET to a signed URI" do
-      net_http.expect :get_response, response, [ %r{^http://example.org/test\?.*Signature=} ]
+      net_http.expect :get_response, response, [ %r{^https://example.org/test\?.*Signature=} ]
       response.expect :is_a?, true, [ Net::HTTPSuccess ]
       response.expect :body, "<xml/>"
       client.get("example.org", "/test", "a" => "b").must_equal "<xml/>"
     end
 
     it "raises an error if the HTTP request failed" do
-      net_http.expect :get_response, response, [ %r{^http://example.org/test\?.*Signature=} ]
+      net_http.expect :get_response, response, [ %r{^https://example.org/test\?.*Signature=} ]
       response.expect :is_a?, false, [ Net::HTTPSuccess ]
       def response.error!; raise Net::HTTPError.new("", self); end
       ->{ client.get("example.org", "/test", "a" => "b") }.must_raise Net::HTTPError


### PR DESCRIPTION
### Background Context

Amazon is deprecating the HTTP endpoint for AWIS and Alexa TopSites APIs on Thursday August 24, 2017.

### Action

- [x] Replace use of `http` with `https`
- [x] Update specs
- [x] Add a console task to the Rakefile

### How to QA

- Use console task to request top sites

```ruby
irb> session = Ralexa::Session.new(KEY, SECRET) # see `flippa-rails` configuration for credentials
irb> session.top_sites.global(10).each { |r| p r }
```

- You get 10 results as expected.

### JIRA

https://flippa.atlassian.net/browse/PES-809