### PR TITLE
Bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [0.0.9] - 2017-08-17
+### Changed
+- Request to Amazon Alexa APIs using `https` scheme as use of `http` is being deprecated

--- a/lib/ralexa/version.rb
+++ b/lib/ralexa/version.rb
@@ -1,3 +1,3 @@
 module Ralexa
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end


### PR DESCRIPTION
### Background Context

Modification have been made to the gem to handle upcoming deprecation of `http` endpoint. A new version of the gem needs to be released.

### Action

- [x] Bump version to `0.0.9`
- [x] Add a changelog document
- [x] Tagged commit with `v0.0.9`